### PR TITLE
Use the prop-types package from npm instead of the PropTypes from the…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,13 @@
+# dependencies
+/node_modules
 
+# production
 dist
+
+# misc
+.DS_Store
+.env
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "author": "Brent Jackson",
   "license": "MIT",
   "dependencies": {
-    "geomicons-open": "^3.0.0-beta.2"
+    "geomicons-open": "^3.0.0-beta.2",
+    "prop-types": "^15.5.10"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0"

--- a/src/Icon.js
+++ b/src/Icon.js
@@ -1,5 +1,6 @@
 
 import React from 'react'
+import PropTypes from 'prop-types'
 import paths from 'geomicons-open'
 
 const Icon = ({
@@ -25,12 +26,12 @@ const Icon = ({
 }
 
 Icon.propTypes = {
-  name: React.PropTypes.oneOf(Object.keys(paths)),
-  size: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.number
+  name: PropTypes.oneOf(Object.keys(paths)),
+  size: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number
   ]),
-  fill: React.PropTypes.string
+  fill: PropTypes.string
 }
 
 export default Icon


### PR DESCRIPTION
… main React package, which is deprecated.  This will avoid warnings when using react-geomicons in your projects.

Also amended the .gitignore package that did not contain entries for node_modules and a few other, common ignored files and directories.